### PR TITLE
Fix/candles

### DIFF
--- a/services/candles/run.py
+++ b/services/candles/run.py
@@ -141,7 +141,7 @@ def main(
     # sdf = sdf.update(lambda value: breakpoint())
 
     # sdf = sdf.print()
-    sdf = sdf.apply(lambda x: logger.info(f'Candle: {x}'))
+    sdf = sdf.update(lambda x: logger.info(f'Candle: {x}'))
 
     # Push the candles to the output topic
     sdf.to_topic(topic=output_topic)

--- a/services/candles/run.py
+++ b/services/candles/run.py
@@ -25,6 +25,9 @@ def custom_ts_extractor(
 
 
 def init_candle(trade: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Initialize a candle with the first trade
+    """
     return {
         'open': trade['price'],
         'high': trade['price'],
@@ -36,15 +39,17 @@ def init_candle(trade: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def update_candle(acc: Dict[str, Any], trade: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        'close': trade['price'],
-        'high': max(acc['high'], trade['price']),
-        'low': min(acc['low'], trade['price']),
-        'volume': acc['volume'] + trade['volume'],
-        'timestamp_ms': trade['timestamp_ms'],
-        'pair': trade['pair'],
-    }
+def update_candle(candle: Dict[str, Any], trade: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Update the candle with the latest trade
+    """
+    candle['close'] = trade['price']
+    candle['high'] = max(candle['high'], trade['price'])
+    candle['low'] = min(candle['low'], trade['price'])
+    candle['volume'] = candle['volume'] + trade['volume']
+    candle['timestamp_ms'] = trade['timestamp_ms']
+    candle['pair'] = trade['pair']
+    return candle
 
 
 def main(


### PR DESCRIPTION
已完成
- [x] 修正candles的update_candles函數，讓open值為第一次資料
- [x] 修正candles的印出，不是使用`sdf.apply`(會修改到值)

## Summary by Sourcery

Fix the update_candle function to correctly set the 'open' value and modify the candle update logic to update the existing candle dictionary. Change the logging mechanism to use sdf.update instead of sdf.apply.

Bug Fixes:
- Fix the update_candle function to ensure the 'open' value is set to the first trade's price.

Enhancements:
- Modify the candle update logic to directly update the existing candle dictionary instead of creating a new one.