### PR TITLE
build/Add-docker-compose-for-technical-indicators-pipeline

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -13,3 +13,12 @@ delete-redpanda-topic-all:
 			docker compose -f redpanda.yml exec redpanda rpk topic delete $$topic; \
 		done \
 	fi
+
+build-technical-indicators-pipeline:
+	docker compose -f technical-indicators-pipeline.yml build
+
+start-technical-indicators-pipeline: build-technical-indicators-pipeline
+	docker compose -f technical-indicators-pipeline.yml up -d
+
+stop-technical-indicators-pipeline:
+	docker compose -f technical-indicators-pipeline.yml down

--- a/docker-compose/technical-indicators-pipeline.yml
+++ b/docker-compose/technical-indicators-pipeline.yml
@@ -1,0 +1,59 @@
+name: technical-indicators-pipeline
+networks:
+  redpanda_network:
+    external: true
+    name: redpanda-dev-cluster_redpanda_network
+
+services:
+  trades:
+    image: trades
+    build:
+      context: ../services/trades
+      dockerfile: Dockerfile
+    networks:
+      - redpanda_network
+    env_file:
+      - ../services/trades/.env
+    environment:
+      - KAFKA_BROKER_ADDRESS=redpanda:9092
+    restart: always
+
+  candles:
+    image: candles
+    build:
+      context: ../services/candles
+      dockerfile: Dockerfile
+    networks:
+      - redpanda_network
+    env_file:
+      - ../services/candles/.env
+    environment:
+      - KAFKA_BROKER_ADDRESS=redpanda:9092
+    restart: always
+
+  technical-indicators:
+    image: technical-indicators
+    build:
+      context: ../services/technical-indicators
+      dockerfile: Dockerfile
+    networks:
+      - redpanda_network
+    env_file:
+      - ../services/technical-indicators/.env
+    environment:
+      - KAFKA_BROKER_ADDRESS=redpanda:9092
+    restart: always
+
+  to-feature-store:
+    image: to-feature-store
+    build:
+      context: ../services/to-feature-store
+      dockerfile: Dockerfile
+    networks:
+      - redpanda_network
+    env_file:
+      - ../services/to-feature-store/.env
+      - ../services/to-feature-store/credentials.env
+    environment:
+      - KAFKA_BROKER_ADDRESS=redpanda:9092
+    restart: always

--- a/docker-compose/technical-indicators-pipeline.yml
+++ b/docker-compose/technical-indicators-pipeline.yml
@@ -16,7 +16,7 @@ services:
       - ../services/trades/.env
     environment:
       - KAFKA_BROKER_ADDRESS=redpanda:9092
-    restart: always
+    restart: unless-stopped
 
   candles:
     image: candles
@@ -29,7 +29,7 @@ services:
       - ../services/candles/.env
     environment:
       - KAFKA_BROKER_ADDRESS=redpanda:9092
-    restart: always
+    restart: unless-stopped
 
   technical-indicators:
     image: technical-indicators
@@ -42,7 +42,7 @@ services:
       - ../services/technical-indicators/.env
     environment:
       - KAFKA_BROKER_ADDRESS=redpanda:9092
-    restart: always
+    restart: unless-stopped
 
   to-feature-store:
     image: to-feature-store
@@ -56,4 +56,4 @@ services:
       - ../services/to-feature-store/credentials.env
     environment:
       - KAFKA_BROKER_ADDRESS=redpanda:9092
-    restart: always
+    restart: unless-stopped


### PR DESCRIPTION
已完成
- [x] Add docker compose for technical-indicators-pipeline
- [x] Add docker compose command to Makefile

## Summary by Sourcery

Build:
- Add docker-compose configuration for the technical-indicators-pipeline, including services for trades, candles, technical-indicators, and to-feature-store.